### PR TITLE
fix: Update Serai (`hrf`) submodule

### DIFF
--- a/scripts/linux/build_all.sh
+++ b/scripts/linux/build_all.sh
@@ -6,7 +6,7 @@ mkdir -p build
 
 rm -rf "$ROOT_DIR"/src/serai/target
 
-cd "$ROOT_DIR"/src/serai/hrf || exit
+cd "$ROOT_DIR"/src/serai || exit
 if [ "$IS_ARM" = true ]  ; then
     echo "Building arm frostdart"
     cargo +1.71.0 build --target aarch64-unknown-linux-gnu --release --lib


### PR DESCRIPTION
Stack Wallet cannot currently be compiled from source as the version of serai that `frostdart` uses is referencing a repository that has been deleted (https://github.com/serai-dex/schnorrkel)

This PR update the submodule to include the latest fix commits.