### PR TITLE
fix(android): pin injected openssl to <=0.10.78 for rustc 1.71

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           ANDROID_NDK_ROOT: /opt/android-ndk-r28
         run: |
           cd src/serai/hrf
-          sed -i 's/\[dependencies\]/[dependencies]\nopenssl = { version = "0.10", features = ["vendored"] }/' Cargo.toml
+          sed -i 's/\[dependencies\]/[dependencies]\nopenssl = { version = "<=0.10.78", features = ["vendored"] }/' Cargo.toml
           cargo +1.71.0 ndk --target ${{ matrix.target }} --platform 21 build --release
           cp ../target/${{ matrix.target }}/release/libhrf_api.so \
              ../../../frostdart-android-${{ matrix.abi }}.so

--- a/scripts/android/build_all.sh
+++ b/scripts/android/build_all.sh
@@ -43,7 +43,7 @@ cd build/serai/hrf || exit
 
 # inject vendored openssl required for android cross compilation
 sed -i "s/\[dependencies\]/\[dependencies\]\\
-openssl = { version = \"0.10\", features = [\"vendored\"] }/" Cargo.toml
+openssl = { version = \"<=0.10.78\", features = [\"vendored\"] }/" Cargo.toml
 
 rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android
 cargo ndk \


### PR DESCRIPTION
 openssl 0.10.79 bumped MSRV to 1.80, breaking the Android build which uses rustc 1.71.0. 
 Cap the injected vendored-openssl version at 0.10.78 (MSRV 1.70) in both the release workflow and the local build script.
  
  